### PR TITLE
chore(aqua): update pinned packages (2026-08-30)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -21,15 +21,15 @@ packages:
   # Moonshot's CDN (self-contained Node-SEA, no Node runtime). NOTE: the CDN's
   # `latest` can lag GitHub tags, so `aqua up` may propose a version not yet on the
   # CDN — keep this at a CDN-present version (binaries/<ver>/manifest.json resolves).
-  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.38.0
+  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.39.1
     registry: third-party
   # ----- standard registry -----
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.1.21
+  - name: google-antigravity/antigravity-cli@1.1.22
   - name: nektos/act@v0.2.89
-  - name: FiloSottile/age@v1.3.1
+  - name: FiloSottile/age@v1.3.2
   - name: asciinema/asciinema@v3.2.1
   - name: atuinsh/atuin@v18.20.1
   - name: axodotdev/cargo-dist@v0.32.0 # `dist` — was a live-only cargo install
@@ -40,8 +40,8 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.247
-  - name: openai/codex@rust-v0.150.0
+  - name: anthropics/claude-code@v2.1.251
+  - name: openai/codex@rust-v0.151.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
@@ -65,7 +65,7 @@ packages:
   - name: dlvhdr/gh-dash@v4.25.2
   - name: x-motemen/ghq@v1.10.1
   - name: gitlab.com/gitlab-org/cli@v1.99.0 # glab
-  - name: git-lfs/git-lfs@v3.7.1
+  - name: git-lfs/git-lfs@v3.8.0
   - name: charmbracelet/glow@v3.0.0
   - name: carapace-sh/carapace-bin@v1.7.3
   - name: jqlang/jq@jq-1.8.2
@@ -93,24 +93,24 @@ packages:
   - name: starship/starship@v1.26.0
   - name: JohnnyMorganz/StyLua@v2.5.2
   - name: Kampfkarren/selene@0.31.0
-  - name: crate-ci/typos@v1.49.0
+  - name: crate-ci/typos@v1.50.0
   - name: zizmorcore/zizmor@v1.29.0
   - name: gitleaks/gitleaks@v8.30.1
   - name: koalaman/shellcheck@v0.11.0
-  - name: mvdan/sh@v3.13.1
+  - name: mvdan/sh@v3.14.0
   - name: rhysd/actionlint@v1.7.12
-  - name: astral-sh/ruff@0.16.4
+  - name: astral-sh/ruff@0.16.5
   - name: astral-sh/ty@0.0.75
-  - name: j178/prek@v0.4.14
+  - name: j178/prek@v0.5.0
   - name: golang.org/x/tools/gopls@v0.23.0
-  - name: golangci/golangci-lint@v2.13.1
+  - name: golangci/golangci-lint@v2.13.2
   - name: goreleaser/goreleaser@v2.18.0
   - name: orhun/git-cliff@v2.13.1
   - name: numtide/treefmt@v2.5.0
   - name: XAMPPRocky/tokei@14.0.0
   - name: sharkdp/hyperfine@v1.20.0
   - name: hatoo/oha@v1.16.0
-  - name: ClementTsang/bottom@0.14.8
+  - name: ClementTsang/bottom@0.14.9
   - name: dalance/procs@v0.14.12
   - name: sharkdp/hexyl@v0.17.0
   - name: mr-karan/doggo@v1.3.0
@@ -128,8 +128,8 @@ packages:
   - name: ahmetb/kubectx@v0.11.0
   - name: kubernetes-sigs/krew@v0.5.0
   - name: aquasecurity/trivy@v0.74.0
-  - name: anchore/syft@v1.51.0
-  - name: anchore/grype@v0.117.0
+  - name: anchore/syft@v1.51.1
+  - name: anchore/grype@v0.118.0
   - name: LucasPickering/slumber@v5.3.0
   - name: charmbracelet/gum@v2.0.0
   - name: charmbracelet/vhs@v0.11.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.