### PR TITLE
chore(aqua): update pinned packages (2026-09-02)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -27,7 +27,7 @@ packages:
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.1.22
+  - name: google-antigravity/antigravity-cli@1.1.23
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.2
   - name: asciinema/asciinema@v3.2.1
@@ -40,14 +40,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.252
-  - name: openai/codex@rust-v0.152.0
+  - name: anthropics/claude-code@v2.1.258
+  - name: openai/codex@rust-v0.152.1
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.8.16
+  - name: jdx/mise@v2026.9.0
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -57,11 +57,11 @@ packages:
   # Darwin uses Cargo for eza. Track crates.io releases directly: GitHub tag
   # v0.23.5 existed before its crate, which made aqua's Cargo install impossible.
   - name: crates.io/eza@0.23.5
-  - name: fastfetch-cli/fastfetch@2.67.1
+  - name: fastfetch-cli/fastfetch@2.68.1
   - name: sharkdp/fd@v10.5.0
   - name: junegunn/fzf@v0.74.3
   - name: gopasspw/gopass@v1.17.0
-  - name: cli/cli@v2.98.0
+  - name: cli/cli@v2.99.0
   - name: dlvhdr/gh-dash@v4.25.2
   - name: x-motemen/ghq@v1.10.1
   - name: gitlab.com/gitlab-org/cli@v1.99.0 # glab
@@ -93,7 +93,7 @@ packages:
   - name: starship/starship@v1.26.0
   - name: JohnnyMorganz/StyLua@v2.5.2
   - name: Kampfkarren/selene@0.31.0
-  - name: crate-ci/typos@v1.50.0
+  - name: crate-ci/typos@v1.50.1
   - name: zizmorcore/zizmor@v1.30.0
   - name: gitleaks/gitleaks@v8.30.1
   - name: koalaman/shellcheck@v0.11.0
@@ -101,11 +101,11 @@ packages:
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.16.5
   - name: astral-sh/ty@0.0.77
-  - name: j178/prek@v0.5.0
+  - name: j178/prek@v0.5.1
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.13.2
   - name: goreleaser/goreleaser@v2.18.0
-  - name: orhun/git-cliff@v2.13.1
+  - name: orhun/git-cliff@v2.14.1
   - name: numtide/treefmt@v2.6.0
   - name: XAMPPRocky/tokei@14.0.0
   - name: sharkdp/hyperfine@v1.20.0
@@ -113,11 +113,11 @@ packages:
   - name: ClementTsang/bottom@0.14.9
   - name: dalance/procs@v0.14.12
   - name: sharkdp/hexyl@v0.17.0
-  - name: mr-karan/doggo@v1.3.0
+  - name: mr-karan/doggo@v1.4.0
     registry: third-party
   - name: sharkdp/vivid@v0.11.1
   - name: dduan/tre@v0.4.0
-  - name: sxyazi/yazi@v26.8.15
+  - name: sxyazi/yazi@v26.9.1
   - name: mikefarah/yq@v4.53.6
   - name: ajeetdsouza/zoxide@v0.10.0
   - name: derailed/k9s@v0.51.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.