### PR TITLE
fix: correct README drift and stop chezmoi applying stray artifacts

### DIFF
--- a/.chezmoidata/claude.yaml
+++ b/.chezmoidata/claude.yaml
@@ -7,7 +7,9 @@ claude:
   #   - providers: Provider definitions (base_url + available models)
   #   - accounts: Account configurations (model selection + settings)
   #
-  # API keys stored in gopass: claude/providers/{provider}/accounts/{base64url(account)}/api_key
+  # API keys stored in gopass: claude/<provider>/<account-label>/api_key
+  # (`<account-label>` is the part after `@`, or `default` when the account name
+  # carries no `@`). See dot_local/bin/lib/ai/core.tmpl:api_key_path.
 
   # ===== Global Defaults =====
   # Fallback when neither account nor provider specifies a value.

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -9,6 +9,14 @@ SECURITY.md
 CLAUDE.md
 AGENTS.md
 
+# Local build artifacts and stray logs. These are in .gitignore, but .gitignore
+# does not stop chezmoi: anything left in the source tree becomes a managed
+# target, so a `nix build` here would apply `~/result` and a proxy/tool log
+# dropped in this directory would be copied into $HOME.
+result
+result-*
+*.log
+
 # Python bytecode (defensive -- bundled skill scripts are currently bash, but
 # leave the ignore in place for future Python-backed helpers)
 **/__pycache__/

--- a/README.ja.md
+++ b/README.ja.md
@@ -72,6 +72,9 @@ README は現在のソースファイルに対応しています。
 
 ```text
 .
+├── .chezmoi.toml.tmpl         # 初回 prompt と派生データの定義
+├── .chezmoiignore             # OS / headless / 暗号化による除外
+├── .chezmoitemplates/shell/   # 共有スニペット（age wrapper、nix env 読み込み）
 ├── .chezmoidata/
 │   ├── nix.yaml              # Nix ユーザー/システムパッケージデータ
 │   ├── homebrew.yaml         # taps、formulae、cask、MAS
@@ -84,20 +87,25 @@ README は現在のソースファイルに対応しています。
 │   └── versions.yaml         # installer、package、skill revisions
 ├── .chezmoiexternal.toml.tmpl # TPM と共有 skill archive
 ├── .chezmoiscripts/           # 番号付き bootstrap/保守スクリプト
+├── init.sh                    # HTTPS 専用の bootstrap 入口
+├── Justfile.tmpl              # ~/Justfile として展開（「日常運用」参照）
 ├── nix-config/                # flake、nix-darwin/profile モジュール
-├── dot_claude/                # Claude 設定、hooks、指示
+├── dot_zshenv、dot_zshrc ほか # zsh の入口（dot_gitconfig は空のスタブ）
+├── dot_custom/                # exports、alias、関数、fzf-tab（~/.custom）
+├── dot_claude/                # Claude 設定、hooks、context、CI テンプレート
 ├── dot_codex/                 # Codex 設定、prompts、指示
-├── dot_pi/                    # Pi 設定、models、agents、MCP、themes
+├── dot_pi/                    # Pi 設定、models、agents、MCP、themes、検索
 ├── dot_cursor/                # Cursor CLI 設定と MCP
-├── dot_kimi-code/             # Kimi の safety 設定と MCP
+├── dot_kimi-code/             # Kimi の safety 設定、MCP、指示
 ├── dot_gemini/                # Antigravity CLI のマージ設定
-├── dot_harnesses/             # ローカル harness commands と skills
+├── dot_harnesses/             # 自作 skills と共有 /commit command
 ├── dot_local/bin/             # account、key、MCP、skill、status helper
-├── private_dot_config/         # shell、tmux、ツール、サービス設定
+├── private_dot_config/        # エディタ、端末、デスクトップ、ツール、サービス設定
+├── private_dot_ssh/           # age 暗号化された SSH client 設定
 ├── private_Library/           # macOS LaunchAgents
 ├── docs/                      # 個別の運用ガイド
 ├── tests/                     # bootstrap/統合回帰テスト
-└── tools/                     # 単体ユーティリティ（WezTerm アイコンなど）
+└── tools/wezterm-icon/        # スクリプト `22` が使う Swift ユーティリティ
 ```
 
 ## Bootstrap フロー: 実際に実行されるもの
@@ -132,7 +140,7 @@ README は現在のソースファイルに対応しています。
 | `19b`  | `run_onchange_after_19_load-systemd-user-units.sh.tmpl`    | Linux のみ。linger と `mcp-reaper.timer` を有効にし、古いローカル Context7 unit を無効にします。                                                                           |
 | `20`   | `run_after_20_update-pi-extensions.sh.tmpl`                | Pi があれば ISO 週/package 集合ごとに `pi update --extensions` を一度実行します。失敗は非致命で次回 apply に再試行します。                                                 |
 | `21`   | `run_onchange_after_21_terminal-profile.sh.tmpl`           | 非 headless macOS のみ。管理対象 Dracula Terminal.app profile を既定にします。                                                                                             |
-| `22`   | `run_after_22_wezterm-icon.sh`                             | macOS のみ。必要な場合、cask 交換後に WezTerm のカスタムアイコンを再適用します。                                                                                           |
+| `22`   | `run_after_22_wezterm-icon.sh`                             | 非 headless macOS のみ。必要な場合、cask 交換後に `tools/wezterm-icon` で WezTerm のカスタムアイコンを再適用します。                                                       |
 | `23`   | `run_after_23_mise-up.sh`                                  | 7 日ごとに `mise up` を実行します。失敗は非致命で、成功時刻は進めません。                                                                                                  |
 
 ## クイックスタート
@@ -212,9 +220,14 @@ HTTPS credential が必要になる場合があります（既存の `gh` login�
 
 ## 日常運用
 
-対話的 shell は
-`JUSTFILE=${XDG_CONFIG_HOME:-$HOME/.config}/just/.justfile`（通常は
-`~/.config/just/.justfile`）を export します。この global justfile には次が含まれます。
+同じ `Justfile.tmpl` から二つの justfile が生成されます。
+
+- `~/.config/just/.justfile` —— global ファイル。対話的 shell が
+  `JUSTFILE=${XDG_CONFIG_HOME:-$HOME/.config}/just/.justfile` を export するため、
+  どのディレクトリでも `just` はこれを使います。
+- `~/Justfile` —— 同じ recipe に `test` を **追加** したもの。ただし `JUSTFILE`
+  が export されているので `just test` はこちらに解決されません。テストは下の
+  コマンドを直接実行してください。
 
 ```bash
 # Chezmoi
@@ -222,46 +235,50 @@ just apply
 just diff
 just update
 just re-add
+just edit <file>
 
 # Nix
 just up                 # 全 flake input を更新
 just upp nixpkgs        # 一つの input を更新
-just gc
+just gc                 # 既定 7 日
 just verify
 just optimize
+just repl
+just repair <paths>
+just gcroot
 
 # macOS only
 just darwin
+just darwin-debug
 just darwin-check
 just darwin-build
+just history
+just clean              # 既定 7 日
 ```
 
-global justfile には回帰テスト recipe は **ありません**。実際のテストは次で実行
-します。
+回帰テストと lint は直接実行します。
 
 ```bash
 bash "$(chezmoi source-path)/tests/run.sh"
 pre-commit run --all-files
 ```
 
-その他の生成 recipe には `edit`、`history`、`repl`、`clean`、`repair`、`gcroot`、
-Git の短縮コマンド（`st`、`gd`、`gl`、`cm`、`push`、`pull`）があります。一部は
-macOS 専用です。`clean` と `gc` の既定期間は 7 日で、引数で変更できます。
+ほかに Git の短縮 recipe（`st`、`gd`、`gl`、`cm`、`push`、`pull`）があります。
 
 ## パッケージとツールの管理
 
 パッケージの source は意図的に分かれており、すべての一覧が `.chezmoidata/`
 にあるわけではありません。
 
-| レイヤー                 | Source                                                            | 管理内容                                                                                                                                                                   |
-| ------------------------ | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Nix ユーザープロファイル | `.chezmoidata/nix.yaml` + `nix-config/modules/profile.nix.tmpl`   | `flakey-profile` で shared と work のパッケージを管理します。現在の `sysPkgs` は空ですが、macOS のシステム設定/フォント/サービスは `nix-darwin` にあります。               |
-| nix-darwin               | `nix-config/modules/*.tmpl`                                       | macOS defaults、フォント、shell/PAM、Nix index、Homebrew、system launchd jobs。                                                                                            |
-| Homebrew                 | `.chezmoidata/homebrew.yaml` + `nix-config/modules/apps.nix.tmpl` | tap、formula、cask、条件付き MAS。ロックされた再現可能な Nix レイヤーではありません。                                                                                      |
-| aqua                     | `private_dot_config/aquaproj-aqua/aqua.yaml` と `registry.yaml`   | Claude/Codex、shell、Kubernetes/security、Kimi Code、Herdr、Slipway、qmk-hid-host など固定版 CLI。                                                                         |
-| mise                     | `private_dot_config/mise/config.toml.tmpl`                        | Node、Bun、Python、Go、Rust、Lua、Terraform、uv、pipx、Pi、使用量分析、browser/media CLI、`xurl`、`crosspost`。`npm:` は Bun を使いますが Node は runtime のため残します。 |
-| 直接 installer           | `.chezmoiscripts/00`、`09`、`15`、`16`                            | Determinate Nix、Paperlib、Cursor Agent、work-only Azure Functions Core Tools。版と checksum は repository のデータで固定します。                                          |
-| Pi extensions            | `.chezmoidata/pi.yaml` + Pi settings                              | 外部 package 5 個と `@signalridge` package 20 個。意図的に pin せず、Pi の週次 `update --extensions` で更新します。                                                        |
+| レイヤー                 | Source                                                              | 管理内容                                                                                                                                                                                                                                |
+| ------------------------ | ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Nix ユーザープロファイル | `.chezmoidata/nix.yaml` + `nix-config/modules/profile.nix.tmpl`     | `flakey-profile` で shared と work のパッケージを管理します。現在の `sysPkgs` は空ですが、macOS のシステム設定/フォント/サービスは `nix-darwin` にあります。                                                                            |
+| nix-darwin               | `nix-config/modules/*.tmpl`                                         | macOS defaults、フォント、shell/PAM、Nix index、Homebrew、system launchd jobs。                                                                                                                                                         |
+| Homebrew                 | `.chezmoidata/homebrew.yaml` + `nix-config/modules/apps.nix.tmpl`   | tap、formula、cask、条件付き MAS。ロックされた再現可能な Nix レイヤーではありません。                                                                                                                                                   |
+| aqua                     | `private_dot_config/aquaproj-aqua/{aqua,registry,aqua-policy}.yaml` | 固定版 CLI: Claude Code、Codex、Antigravity CLI（`agy`）、shell/Kubernetes/security ツール、およびローカル `registry.yaml` の Kimi Code、Herdr、Slipway、qmk-hid-host、doggo。`aqua-policy.yaml` がそのローカル registry を許可します。 |
+| mise                     | `private_dot_config/mise/config.toml.tmpl`                          | Node、Bun、Python、Go、Rust、Lua、Terraform、uv、pipx、Pi、使用量分析、browser/media CLI、`xurl`、`crosspost`。`npm:` は Bun を使いますが Node は runtime のため残します。                                                              |
+| 直接 installer           | `.chezmoiscripts/00`、`09`、`15`、`16`                              | Determinate Nix、Paperlib、Cursor Agent、work-only Azure Functions Core Tools。版と checksum は repository のデータで固定します。                                                                                                       |
+| Pi extensions            | `.chezmoidata/pi.yaml` + Pi settings                                | 外部 package 5 個と `@signalridge` package 20 個。意図的に pin せず、Pi の週次 `update --extensions` で更新します。                                                                                                                     |
 
 代表的なツールは `eza`、`bat`、`fd`、`ripgrep`、`fzf`、`gh`、`ghq`、`just`、
 `lazygit`、`neovim`、`yazi`、`jj`、`xh`、`slumber`、`k9s`、`kubectl`、`helm`、
@@ -269,10 +286,33 @@ macOS 専用です。`clean` と `gc` の既定期間は 7 日で、引数で変
 `aichat`、`agent-browser`、`hyperframes`、`impeccable` です。完全な一覧は上記の
 実際の source file を参照してください。
 
+## エディタ・端末・デスクトップ
+
+`private_dot_config/` はパッケージ表よりも大きなレイヤーで、ワークステーション
+の残り全部を保持しています。
+
+| 領域               | 管理対象の設定                                                                                                                                                                                     |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| エディタ           | `nvim/` —— LazyVim 構成。コミット済みの `lazy-lock.json`、`neoconf.json`、ローカルの `lua/config`・`lua/plugins`（配色、AI、dotfiles）を含みます。                                                 |
+| Shell の外観       | `sheldon/plugins.toml`（zsh プラグイン管理: ohmyzsh lib、`zsh-defer`、autosuggestions、syntax highlighting、`fzf-tab`、`enhancd`、`you-should-use`）、`starship.toml`、`atuin/`。                  |
+| 端末               | `wezterm/wezterm.lua` と同梱の `WezTerm.icns`、Terminal.app 用の `terminal/Dracula.terminal`（スクリプト `21` が導入）。                                                                           |
+| 多重化             | `tmux/tmux.conf.tmpl`（TPM と、さらに 17 個の固定プラグイン: tmux2k ステータスライン + 独自 AI agent セグメント、sessionx、floax、extrakto、resurrect/continuum）と Herdr の `herdr/config.toml`。 |
+| macOS デスクトップ | `aerospace/`（タイル型ウィンドウ管理）、`hammerspoon/`（入力ソース自動切替、マイク/音量 watcher、Spoons）、`private_karabiner/`、`sofle/`（QMK/Vial レイアウト）。                                 |
+| Git とレビュー     | `git/`、`jj/`、`delta/`、`lazygit/`、`git-cliff/`、`gh/`、`gh-dash/`。GitHub は HTTPS + `gh` credential helper で、`insteadOf` の書き換えは **意図的に使いません**。                               |
+| ファイルと観測     | `yazi/`、`bat/`、`bottom/`、`procs/`、`slumber/`、`watchexec/`、`tlrc/`、`lazydocker/`、および `stern/`、`grype/`、`syft/` のポリシー。                                                            |
+| サービスとストア   | `systemd/user/`（Linux の `mcp-reaper.service` と `.timer`）、`nix/nix.conf`、`gopass/config.tmpl`、`mise/`、`aquaproj-aqua/`、`just/`、`aichat/`、`letsencrypt/`。                                |
+
+`tools/wezterm-icon/` は、Homebrew が cask を入れ替えた後にカスタムアイコンを
+再適用するためスクリプト `22` が呼び出す単体の Swift ユーティリティです。
+
 ## Shell alias と関数
 
-Shell 設定は対話的な zsh セッションでのみ読み込まれます。以下の alias は対象
-コマンドが存在する場合だけ作成されます。
+Shell ファイルは `dot_custom/` にあり `~/.custom/` へ展開されます
+（`exports.sh`、`alias.sh`、`functions.sh`、`utils.sh`、`eval.sh`、
+`fzf-tab.zsh`）。`~/.zshrc` がそれらを読み込み、非対話的 shell では早期に
+return します。管理対象外の `~/.custom/local.sh` は最後に読み込まれ、マシン
+固有の上書きに使えます。以下の alias は対象コマンドが存在する場合だけ作成され
+ます。
 
 | Alias                                                 | 対象                                                                             |
 | ----------------------------------------------------- | -------------------------------------------------------------------------------- |
@@ -284,10 +324,16 @@ Shell 設定は対話的な zsh セッションでのみ読み込まれます。
 | `cxm`、`cxw`                                          | `codex-manage`、`codex-with`                                                     |
 | `k` / `kubectl`                                       | `kubecolor` があればそれ、なければ `k` は `kubectl`                              |
 
-`la`、`ll`、`lla`、`lt` は eza/listing helper です。`cp`、`mv`、`mkdir` は
+`la` と `ll` は常に定義されます。`lla` と `lt` は eza がある場合のみ定義され、
+eza の `--git`/`--tree` を使います。`cp`、`mv`、`mkdir` は
 interactive/safe alias（`-i`/`-v` と `mkdir -p`）です。`ripgrep`、`fd`、`zoxide`
 は導入・統合されますが、**`grep`、`find`、`cd` がそれらへ alias されるわけでは
 ありません**。
+
+zsh ではコマンドラインのどこでも展開される global alias もあります ——
+`L`（`| less`）、`G`（`| grep`）、`H`、`T`、`W`、`S`、`U`、`J`（`| jq`）、
+`CP`（`| pbcopy`）、`F`（`$(fzf)`）、リダイレクト用の `N`/`N1`/`N2`。一覧は
+`galias`、直前のコマンドのコピーは `yy` です。`take` は `mkcd` の別名です。
 
 代表的な関数：
 
@@ -313,15 +359,19 @@ repository では Git worktree を使いますが、この chezmoi source 内で
 
 ### 管理対象 harness
 
-| Harness          | 管理ファイルと挙動                                                                                                                                                                            |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Claude Code      | `~/.claude/settings.json`、global instructions、hooks、statusline、official integration plugins。                                                                                             |
-| Codex CLI        | `~/.codex/config.toml`、project-document fallback、lifecycle hooks、MCP、Slack plugin 設定。                                                                                                  |
-| Pi               | `~/.pi/agent/settings.json`、`models.json`、`subagents.json`、workflow settings、themes、keybindings、MCP。Pi は `/model` と `/login` を使い、Pi account wrapper や `pi-token` はありません。 |
-| Cursor Agent CLI | 固定版 `agent`/`cursor-agent` binary と `~/.cursor/cli-config.json`、`~/.cursor/mcp.json`。                                                                                                   |
-| Kimi Code        | `~/.kimi-code/config.toml` の safety defaults と `~/.kimi-code/mcp.json`。account wrapper はありません。                                                                                      |
-| Antigravity CLI  | `~/.gemini/antigravity-cli/settings.json` への deep merge。runtime が管理する model/trust 設定は保持します。                                                                                  |
-| aichat           | `~/.config/aichat/config.yaml`。対応する `pi/...` gopass key があれば Kimi Moonshot と Doubao を書き出します。                                                                                |
+| Harness          | 管理ファイルと挙動                                                                                                                                                                                                                                                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code      | `~/.claude/settings.json`、`CLAUDE.md`、四つの `context/*.md`、`hooks/`、`statusline-command.sh`、`templates/*.yml`（CI 雛形）、official integration plugins。                                                                                                                                                            |
+| Codex CLI        | `~/.codex/config.toml`、`AGENTS.md`、project-document fallback、lifecycle hooks、MCP、Slack plugin 設定。                                                                                                                                                                                                                 |
+| Pi               | `~/.pi/agent/settings.json`、`models.json`、`subagents.json`、`workflows/settings.json`、`mcp.json`、`keybindings.json`、`APPEND_SYSTEM.md`、六つの `agents/*.md`、四つの theme、`pi-permission-system` 設定、`~/.pi/web-search.json`。Pi は `/model` と `/login` を使い、Pi account wrapper や `pi-token` はありません。 |
+| Cursor Agent CLI | 固定版 `agent`/`cursor-agent` binary と `~/.cursor/cli-config.json`、`~/.cursor/mcp.json`。                                                                                                                                                                                                                               |
+| Kimi Code        | `~/.kimi-code/config.toml` の safety defaults、`~/.kimi-code/mcp.json`、`~/.kimi-code/AGENTS.md`。account wrapper はありません。                                                                                                                                                                                          |
+| Antigravity CLI  | `~/.gemini/antigravity-cli/settings.json` への deep merge。runtime が管理する `model`、`permissions`、`trustedWorkspaces` は保持します。                                                                                                                                                                                  |
+| aichat           | `~/.config/aichat/config.yaml`。対応する `pi/...` gopass key があれば Kimi Moonshot と Doubao を書き出します。                                                                                                                                                                                                            |
+
+`~/.claude/skills`、`~/.codex/skills`、`~/.pi/agent/skills`、`~/.cursor/skills`、
+`~/.kimi-code/skills` は `dot_claude/run_after_ensure-skill-dirs.sh` が実ディレ
+クトリとして維持します。既定ではそこに何も有効化されません。
 
 ### Claude/Codex account
 
@@ -393,6 +443,13 @@ Reddit/daily.dev/X publishing、UI/UX/diagram skill、Go/Rust/Swift/TypeScript s
 する仕組みではありません。global `ai-research-skills` CLI は mise の pipx/uvx
 backend で別に管理され、host skills/commands はインストールしません。
 
+三つの skill はダウンロードではなくこのリポジトリで書かれ、同じ library に
+置かれます: `dev/toolbelt`（global agent instructions が参照するローカル CLI
+一覧）、`media/remotion`、`social/oss-x-post`（確認ゲート付きの `social-post` と
+`reddit-submit` 発行ヘルパーを同梱）。共有の `/commit` command は
+`~/.harnesses/commands/core/commit.md` にあり、`~/.claude/commands/core` と
+`~/.codex/prompts/core-commit.md` へ symlink されます。
+
 プロジェクトディレクトリで `skill-activate` を実行すると、選択した skill を次の
 五つのディレクトリへ flat symlink として作成します。
 
@@ -424,6 +481,10 @@ MCP 宣言は harness ごとに同じではありません。
 | Codex       | Notion と上記六つ。                                                                                                                  |
 | Pi          | `context7`、`deepwiki`、`gitmcp` は lazy direct tools、`markitdown` と `arxiv` は lazy proxy tools。ここでは Tavily を宣言しません。 |
 | Cursor/Kimi | `context7`、`tavily`、`deepwiki`、`gitmcp`、`markitdown`、`arxiv`。                                                                  |
+
+Pi の経路は別です。管理対象の `~/.pi/web-search.json` が `pi-web-access` 拡張に
+Exa/Tavily のルーティングを設定し、呼び出し時に gopass から Tavily key を読み、
+ブラウザ cookie の再利用を無効化します。
 
 `~/.local/bin/mcp-tavily` は実行時に gopass の `tavily/api_key` を読み、`bunx` で
 固定版 `tavily-mcp@0.2.16` を起動します。対応する non-headless macOS または

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ The README is deliberately organized around the actual source files:
 
 ```text
 .
+├── .chezmoi.toml.tmpl         # first-run prompts and every derived data value
+├── .chezmoiignore             # OS / headless / encryption exclusions
+├── .chezmoitemplates/shell/   # shared snippets (age wrapper, nix env sourcing)
 ├── .chezmoidata/
 │   ├── nix.yaml              # Nix user/system package data
 │   ├── homebrew.yaml         # taps, formulae, casks, and MAS entries
@@ -86,20 +89,25 @@ The README is deliberately organized around the actual source files:
 │   └── versions.yaml         # pinned installers, packages, and skill revisions
 ├── .chezmoiexternal.toml.tmpl # TPM and shared skill archives
 ├── .chezmoiscripts/           # numbered bootstrap and maintenance scripts
+├── init.sh                    # HTTPS-only bootstrap entry point
+├── Justfile.tmpl              # rendered to ~/Justfile (see Daily Operations)
 ├── nix-config/                # flake and nix-darwin/profile modules
-├── dot_claude/                # Claude settings, hooks, and instructions
+├── dot_zshenv, dot_zshrc, …   # zsh entry points (dot_gitconfig is a stub)
+├── dot_custom/                # exports, aliases, functions, fzf-tab (~/.custom)
+├── dot_claude/                # Claude settings, hooks, context, CI templates
 ├── dot_codex/                 # Codex config, prompts, and instructions
-├── dot_pi/                    # Pi settings, models, agents, MCP, and themes
+├── dot_pi/                    # Pi settings, models, agents, MCP, themes, search
 ├── dot_cursor/                # Cursor CLI settings and MCP
-├── dot_kimi-code/             # Kimi safety settings and MCP
+├── dot_kimi-code/             # Kimi safety settings, MCP, and instructions
 ├── dot_gemini/                # Antigravity CLI settings merge
-├── dot_harnesses/             # local harness commands and skills
+├── dot_harnesses/             # repo-authored skills and the shared /commit command
 ├── dot_local/bin/             # account, key, MCP, skill, and status helpers
-├── private_dot_config/        # shell, tmux, tool, and service configuration
+├── private_dot_config/        # editor, terminal, desktop, tool, service config
+├── private_dot_ssh/           # age-encrypted SSH client config
 ├── private_Library/           # macOS LaunchAgents
 ├── docs/                      # focused operational guides
 ├── tests/                     # bootstrap and integration regression tests
-└── tools/                     # standalone utilities (including WezTerm icon)
+└── tools/wezterm-icon/        # Swift helper used by script `22`
 ```
 
 ## Bootstrap Flow: What Actually Runs
@@ -134,7 +142,7 @@ after apply and perform their own guards or cadence checks.
 | `19b` | `run_onchange_after_19_load-systemd-user-units.sh.tmpl`    | Linux only; enables lingering and the `mcp-reaper.timer` systemd user unit, and disables the old local Context7 unit.                                                                                                        |
 | `20`  | `run_after_20_update-pi-extensions.sh.tmpl`                | When Pi is installed, runs `pi update --extensions` once per ISO week/package set. Failures are non-fatal and retried on the next apply.                                                                                     |
 | `21`  | `run_onchange_after_21_terminal-profile.sh.tmpl`           | Non-headless macOS only; installs the managed Dracula Terminal.app profile as the default.                                                                                                                                   |
-| `22`  | `run_after_22_wezterm-icon.sh`                             | macOS only; reapplies the custom WezTerm icon after cask replacement when needed.                                                                                                                                            |
+| `22`  | `run_after_22_wezterm-icon.sh`                             | Non-headless macOS only; reapplies the custom WezTerm icon (via `tools/wezterm-icon`) after cask replacement when needed.                                                                                                    |
 | `23`  | `run_after_23_mise-up.sh`                                  | Runs `mise up` on a seven-day cadence. A failed upgrade is non-fatal and does not advance the success timestamp.                                                                                                             |
 
 ## Quick Start
@@ -215,9 +223,14 @@ or interactive device-code OAuth.
 
 ## Daily Operations
 
-The interactive shell exports
-`JUSTFILE=${XDG_CONFIG_HOME:-$HOME/.config}/just/.justfile` (normally
-`~/.config/just/.justfile`). That global file contains the following groups:
+Two justfiles are rendered from the same `Justfile.tmpl` source:
+
+- `~/.config/just/.justfile` — the global file. The interactive shell exports
+  `JUSTFILE=${XDG_CONFIG_HOME:-$HOME/.config}/just/.justfile`, so `just` uses
+  this file from any directory.
+- `~/Justfile` — the same recipes **plus** a `test` recipe. Because `JUSTFILE`
+  is exported, `just test` does not resolve to it; run the suite directly
+  instead (below).
 
 ```bash
 # Chezmoi
@@ -225,46 +238,50 @@ just apply
 just diff
 just update
 just re-add
+just edit <file>
 
 # Nix
 just up                 # update all flake inputs
 just upp nixpkgs        # update one input
-just gc
+just gc                 # defaults to 7 days
 just verify
 just optimize
+just repl
+just repair <paths>
+just gcroot
 
 # macOS-only recipes
 just darwin
+just darwin-debug
 just darwin-check
 just darwin-build
+just history
+just clean              # defaults to 7 days
 ```
 
-The global justfile does **not** contain the regression-test recipe. Run the
-actual test suite with:
+Run the regression suite and the lint hooks directly:
 
 ```bash
 bash "$(chezmoi source-path)/tests/run.sh"
 pre-commit run --all-files
 ```
 
-Other generated recipes include `edit`, `history`, `repl`, `clean`, `repair`,
-`gcroot`, and the short Git commands (`st`, `gd`, `gl`, `cm`, `push`, `pull`);
-some are macOS-only. `clean` and `gc` default to seven days unless overridden.
+There are also short Git recipes (`st`, `gd`, `gl`, `cm`, `push`, `pull`).
 
 ## Package and Tool Management
 
 Package sources are intentionally split; not every list lives in
 `.chezmoidata/`.
 
-| Layer             | Source                                                            | What it manages                                                                                                                                                                                          |
-| ----------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Nix user profile  | `.chezmoidata/nix.yaml` + `nix-config/modules/profile.nix.tmpl`   | Shared packages plus work packages through `flakey-profile`. The current `sysPkgs` list is empty; macOS system settings/fonts/services still live in `nix-darwin`.                                       |
-| nix-darwin        | `nix-config/modules/*.tmpl`                                       | macOS defaults, fonts, shell/PAM settings, Nix index, Homebrew integration, and system launchd jobs.                                                                                                     |
-| Homebrew          | `.chezmoidata/homebrew.yaml` + `nix-config/modules/apps.nix.tmpl` | Taps, formulae, casks, and conditional MAS entries. Homebrew is not a locked/reproducible Nix layer.                                                                                                     |
-| aqua              | `private_dot_config/aquaproj-aqua/aqua.yaml` and `registry.yaml`  | Pinned CLI releases, including Claude/Codex, shell tools, Kubernetes/security tools, Kimi Code, Herdr, Slipway, and qmk-hid-host.                                                                        |
-| mise              | `private_dot_config/mise/config.toml.tmpl`                        | Node, Bun, Python, Go, Rust, Lua, Terraform, uv, pipx tools, Pi, usage analyzers, browser/media CLIs, `xurl`, and `crosspost`. `npm:` entries use Bun; Node remains installed for runtime compatibility. |
-| Direct installers | `.chezmoiscripts/00`, `09`, `15`, and `16`                        | Determinate Nix, Paperlib, Cursor Agent, and work-only Azure Functions Core Tools with repository-pinned versions/checksums.                                                                             |
-| Pi extensions     | `.chezmoidata/pi.yaml` + Pi settings                              | Five external packages and twenty `@signalridge` packages, deliberately unpinned and refreshed by Pi's weekly `update --extensions` step.                                                                |
+| Layer             | Source                                                              | What it manages                                                                                                                                                                                                                                 |
+| ----------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Nix user profile  | `.chezmoidata/nix.yaml` + `nix-config/modules/profile.nix.tmpl`     | Shared packages plus work packages through `flakey-profile`. The current `sysPkgs` list is empty; macOS system settings/fonts/services still live in `nix-darwin`.                                                                              |
+| nix-darwin        | `nix-config/modules/*.tmpl`                                         | macOS defaults, fonts, shell/PAM settings, Nix index, Homebrew integration, and system launchd jobs.                                                                                                                                            |
+| Homebrew          | `.chezmoidata/homebrew.yaml` + `nix-config/modules/apps.nix.tmpl`   | Taps, formulae, casks, and conditional MAS entries. Homebrew is not a locked/reproducible Nix layer.                                                                                                                                            |
+| aqua              | `private_dot_config/aquaproj-aqua/{aqua,registry,aqua-policy}.yaml` | Pinned CLI releases: Claude Code, Codex, Antigravity CLI (`agy`), shell/Kubernetes/security tools, and — from the local `registry.yaml` — Kimi Code, Herdr, Slipway, qmk-hid-host, and doggo. `aqua-policy.yaml` authorizes the local registry. |
+| mise              | `private_dot_config/mise/config.toml.tmpl`                          | Node, Bun, Python, Go, Rust, Lua, Terraform, uv, pipx tools, Pi, usage analyzers, browser/media CLIs, `xurl`, and `crosspost`. `npm:` entries use Bun; Node remains installed for runtime compatibility.                                        |
+| Direct installers | `.chezmoiscripts/00`, `09`, `15`, and `16`                          | Determinate Nix, Paperlib, Cursor Agent, and work-only Azure Functions Core Tools with repository-pinned versions/checksums.                                                                                                                    |
+| Pi extensions     | `.chezmoidata/pi.yaml` + Pi settings                                | Five external packages and twenty `@signalridge` packages, deliberately unpinned and refreshed by Pi's weekly `update --extensions` step.                                                                                                       |
 
 Representative configured tools include `eza`, `bat`, `fd`, `ripgrep`, `fzf`,
 `gh`, `ghq`, `just`, `lazygit`, `neovim`, `yazi`, `jj`, `xh`, `slumber`,
@@ -272,10 +289,33 @@ Representative configured tools include `eza`, `bat`, `fd`, `ripgrep`, `fzf`,
 `quarto`, `typst`, `aichat`, `agent-browser`, `hyperframes`, and
 `impeccable`. The full lists are in the source files above.
 
+## Editor, Terminal, and Desktop
+
+`private_dot_config/` is a larger layer than the package tables suggest; it
+holds the rest of the workstation:
+
+| Area                 | Managed configuration                                                                                                                                                                                                      |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Editor               | `nvim/` — a LazyVim setup with a committed `lazy-lock.json`, `neoconf.json`, and local `lua/config` + `lua/plugins` overrides (colorscheme, AI, dotfiles).                                                                 |
+| Shell chrome         | `sheldon/plugins.toml` (zsh plugin manager: ohmyzsh libs, `zsh-defer`, autosuggestions, syntax highlighting, `fzf-tab`, `enhancd`, `you-should-use`), `starship.toml`, and `atuin/`.                                       |
+| Terminals            | `wezterm/wezterm.lua` plus the bundled `WezTerm.icns`, and `terminal/Dracula.terminal` for Terminal.app (installed by script `21`).                                                                                        |
+| Multiplexers         | `tmux/tmux.conf.tmpl` with TPM and seventeen further plugins (tmux2k statusline with a custom AI-agent segment, sessionx, floax, extrakto, resurrect/continuum), plus `herdr/config.toml` for the Herdr workspace manager. |
+| macOS desktop        | `aerospace/` (tiling window manager), `hammerspoon/` (IME auto-switch, mic/volume watchers, Spoons), `private_karabiner/`, and `sofle/` (QMK/Vial keyboard layout).                                                        |
+| Git and review       | `git/`, `jj/`, `delta/`, `lazygit/`, `git-cliff/`, `gh/`, `gh-dash/`. GitHub access is HTTPS through the `gh` credential helper; there are deliberately **no** `insteadOf` rewrites.                                       |
+| Files and inspection | `yazi/`, `bat/`, `bottom/`, `procs/`, `slumber/`, `watchexec/`, `tlrc/`, `lazydocker/`, and the `stern/`, `grype/`, `syft/` policy files.                                                                                  |
+| Services and stores  | `systemd/user/` (`mcp-reaper.service` + `.timer` on Linux), `nix/nix.conf`, `gopass/config.tmpl`, `mise/`, `aquaproj-aqua/`, `just/`, `aichat/`, and `letsencrypt/`.                                                       |
+
+`tools/wezterm-icon/` is the standalone Swift helper that script `22` calls to
+reapply the custom WezTerm icon after Homebrew replaces the cask.
+
 ## Shell Aliases and Functions
 
-Shell setup is loaded for interactive zsh sessions only. The aliases below are
-conditional on the target command being installed:
+Shell files live in `dot_custom/` and are applied to `~/.custom/`
+(`exports.sh`, `alias.sh`, `functions.sh`, `utils.sh`, `eval.sh`,
+`fzf-tab.zsh`); `~/.zshrc` sources them and returns early for non-interactive
+shells. An unmanaged `~/.custom/local.sh` is sourced last for machine-local
+overrides. The aliases below are conditional on the target command being
+installed:
 
 | Alias                                                 | Target                                                                           |
 | ----------------------------------------------------- | -------------------------------------------------------------------------------- |
@@ -287,10 +327,17 @@ conditional on the target command being installed:
 | `cxm`, `cxw`                                          | `codex-manage`, `codex-with`                                                     |
 | `k` / `kubectl`                                       | `kubecolor` when installed; otherwise `k` points to `kubectl`                    |
 
-`la`, `ll`, `lla`, `lt` are eza/listing helpers. `cp`, `mv`, and `mkdir` are
+`la` and `ll` always exist; `lla` and `lt` are defined only when eza is
+installed (they use eza's `--git`/`--tree` flags). `cp`, `mv`, and `mkdir` are
 interactive/safe aliases (`-i`/`-v`, plus `mkdir -p`). `ripgrep`, `fd`, and
 `zoxide` are installed/integrated, but **`grep`, `find`, and `cd` are not
 aliased** to them.
+
+Under zsh there is also a set of global aliases that expand anywhere on the
+command line — `L` (`| less`), `G` (`| grep`), `H`, `T`, `W`, `S`, `U`,
+`J` (`| jq`), `CP` (`| pbcopy`), `F` (`$(fzf)`), and `N`/`N1`/`N2` for output
+redirection — plus `galias` to list them and `yy` to copy the previous command
+to the clipboard. `take` is a second name for `mkcd`.
 
 Common functions:
 
@@ -317,15 +364,20 @@ and defaults to `claude` in the managed shell exports.
 
 ### Managed harnesses
 
-| Harness          | Managed files and behavior                                                                                                                                                                             |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Claude Code      | `~/.claude/settings.json`, global instructions, hooks, statusline, and official integration plugins.                                                                                                   |
-| Codex CLI        | `~/.codex/config.toml`, project-document fallback list, lifecycle hooks, MCP, and the Slack plugin configuration.                                                                                      |
-| Pi               | `~/.pi/agent/settings.json`, `models.json`, `subagents.json`, workflow settings, themes, keybindings, and MCP. Pi uses its native `/model` and `/login`; there is no Pi account wrapper or `pi-token`. |
-| Cursor Agent CLI | Pinned `agent`/`cursor-agent` binary plus `~/.cursor/cli-config.json` and `~/.cursor/mcp.json`.                                                                                                        |
-| Kimi Code        | `~/.kimi-code/config.toml` safety defaults and `~/.kimi-code/mcp.json`; no account wrapper is provided.                                                                                                |
-| Antigravity CLI  | A deep merge into `~/.gemini/antigravity-cli/settings.json`; runtime-owned model/trust settings are preserved.                                                                                         |
-| aichat           | `~/.config/aichat/config.yaml`, with Kimi Moonshot and Doubao entries when their `pi/...` gopass keys exist.                                                                                           |
+| Harness          | Managed files and behavior                                                                                                                                                                                                                                                                                                                       |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Claude Code      | `~/.claude/settings.json`, `CLAUDE.md`, the four `context/*.md` files, `hooks/`, `statusline-command.sh`, the `templates/*.yml` CI starters, and the official integration plugins.                                                                                                                                                               |
+| Codex CLI        | `~/.codex/config.toml`, `AGENTS.md`, the project-document fallback list, lifecycle hooks, MCP, and the Slack plugin configuration.                                                                                                                                                                                                               |
+| Pi               | `~/.pi/agent/settings.json`, `models.json`, `subagents.json`, `workflows/settings.json`, `mcp.json`, `keybindings.json`, `APPEND_SYSTEM.md`, six `agents/*.md` definitions, four themes, the `pi-permission-system` config, and `~/.pi/web-search.json`. Pi uses its native `/model` and `/login`; there is no Pi account wrapper or `pi-token`. |
+| Cursor Agent CLI | Pinned `agent`/`cursor-agent` binary plus `~/.cursor/cli-config.json` and `~/.cursor/mcp.json`.                                                                                                                                                                                                                                                  |
+| Kimi Code        | `~/.kimi-code/config.toml` safety defaults, `~/.kimi-code/mcp.json`, and `~/.kimi-code/AGENTS.md`; no account wrapper is provided.                                                                                                                                                                                                               |
+| Antigravity CLI  | A deep merge into `~/.gemini/antigravity-cli/settings.json`; runtime-owned `model`, `permissions`, and `trustedWorkspaces` are preserved.                                                                                                                                                                                                        |
+| aichat           | `~/.config/aichat/config.yaml`, with Kimi Moonshot and Doubao entries when their `pi/...` gopass keys exist.                                                                                                                                                                                                                                     |
+
+Claude's `~/.claude/skills`, `~/.codex/skills`, `~/.pi/agent/skills`,
+`~/.cursor/skills`, and `~/.kimi-code/skills` are kept as real directories by
+`dot_claude/run_after_ensure-skill-dirs.sh`; nothing is activated there by
+default.
 
 ### Claude and Codex accounts
 
@@ -400,6 +452,13 @@ not a blanket Claude marketplace installation. The global `ai-research-skills`
 CLI is managed separately by mise's pipx/uvx backend; it does not install host
 skills or commands.
 
+Three skills are authored in this repository rather than downloaded, and land
+in the same library: `dev/toolbelt` (the local CLI inventory referenced from the
+global agent instructions), `media/remotion`, and `social/oss-x-post` (which
+bundles the gated `social-post` and `reddit-submit` publish helpers). The shared
+`/commit` command lives at `~/.harnesses/commands/core/commit.md` and is
+symlinked into `~/.claude/commands/core` and `~/.codex/prompts/core-commit.md`.
+
 Run `skill-activate` from a project directory to create flat symlinks for the
 same selected skills in all five directories:
 
@@ -431,6 +490,10 @@ MCP declarations are intentionally not identical in every harness:
 | Codex           | Notion plus the same six entries above.                                                                                               |
 | Pi              | `context7`, `deepwiki`, `gitmcp` as lazy direct tools; `markitdown` and `arxiv` as lazy proxy tools. Pi does not declare Tavily here. |
 | Cursor and Kimi | `context7`, `tavily`, `deepwiki`, `gitmcp`, `markitdown`, and `arxiv`.                                                                |
+
+Pi reaches Tavily through a different path: the managed `~/.pi/web-search.json`
+configures the `pi-web-access` extension with an Exa/Tavily routing pair, reads
+the Tavily key from gopass at call time, and disables browser-cookie reuse.
 
 `~/.local/bin/mcp-tavily` reads `tavily/api_key` from gopass at runtime and
 launches the pinned `tavily-mcp@0.2.16` through `bunx`. When the corresponding

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -72,6 +72,9 @@ README 按当前实际源文件组织：
 
 ```text
 .
+├── .chezmoi.toml.tmpl         # 首次运行的 prompt 与全部派生数据
+├── .chezmoiignore             # OS / headless / 加密相关的排除规则
+├── .chezmoitemplates/shell/   # 共享片段（age wrapper、nix 环境加载）
 ├── .chezmoidata/
 │   ├── nix.yaml              # Nix 用户/系统包数据
 │   ├── homebrew.yaml         # taps、formulae、cask、MAS 条目
@@ -84,20 +87,25 @@ README 按当前实际源文件组织：
 │   └── versions.yaml         # installer、package 和 skill revisions
 ├── .chezmoiexternal.toml.tmpl # TPM 与共享 skills archive
 ├── .chezmoiscripts/           # 编号式 bootstrap/维护脚本
+├── init.sh                    # 仅 HTTPS 的 bootstrap 入口
+├── Justfile.tmpl              # 渲染为 ~/Justfile（见"日常操作"）
 ├── nix-config/                # flake、nix-darwin/profile 模块
-├── dot_claude/                # Claude 设置、hooks、指令
+├── dot_zshenv、dot_zshrc 等   # zsh 入口（dot_gitconfig 只是占位）
+├── dot_custom/                # exports、alias、函数、fzf-tab（~/.custom）
+├── dot_claude/                # Claude 设置、hooks、context、CI 模板
 ├── dot_codex/                 # Codex 配置、prompts、指令
-├── dot_pi/                    # Pi 设置、models、agents、MCP、themes
+├── dot_pi/                    # Pi 设置、models、agents、MCP、themes、搜索
 ├── dot_cursor/                # Cursor CLI 设置与 MCP
-├── dot_kimi-code/             # Kimi safety 设置与 MCP
+├── dot_kimi-code/             # Kimi safety 设置、MCP 与指令
 ├── dot_gemini/                # Antigravity CLI 合并配置
-├── dot_harnesses/             # 本地 harness commands 与 skills
+├── dot_harnesses/             # 仓库自带 skills 与共享 /commit command
 ├── dot_local/bin/             # account、key、MCP、skill、status helpers
-├── private_dot_config/        # shell、tmux、工具和服务配置
+├── private_dot_config/        # 编辑器、终端、桌面、工具与服务配置
+├── private_dot_ssh/           # age 加密的 SSH client 配置
 ├── private_Library/           # macOS LaunchAgents
 ├── docs/                      # 专项运维指南
 ├── tests/                     # bootstrap 与集成回归测试
-└── tools/                     # 独立工具（包括 WezTerm 图标）
+└── tools/wezterm-icon/        # 脚本 `22` 使用的 Swift 工具
 ```
 
 ## Bootstrap 流程：实际执行内容
@@ -131,7 +139,7 @@ README 按当前实际源文件组织：
 | `19b` | `run_onchange_after_19_load-systemd-user-units.sh.tmpl`    | 仅 Linux；启用 linger 和 `mcp-reaper.timer` systemd user unit，并禁用旧的本地 Context7 unit。                                                                |
 | `20`  | `run_after_20_update-pi-extensions.sh.tmpl`                | Pi 已安装时，每个 ISO 周/package 集合运行一次 `pi update --extensions`；失败不阻断 apply，并在下次 apply 重试。                                              |
 | `21`  | `run_onchange_after_21_terminal-profile.sh.tmpl`           | 仅非 headless macOS；安装托管的 Dracula Terminal.app profile 并设为默认。                                                                                    |
-| `22`  | `run_after_22_wezterm-icon.sh`                             | 仅 macOS；需要时在 cask 替换 WezTerm 后重新应用自定义图标。                                                                                                  |
+| `22`  | `run_after_22_wezterm-icon.sh`                             | 仅非 headless macOS；需要时在 cask 替换 WezTerm 后，通过 `tools/wezterm-icon` 重新应用自定义图标。                                                           |
 | `23`  | `run_after_23_mise-up.sh`                                  | 每 7 天运行 `mise up`；失败不致命，也不会推进成功时间戳。                                                                                                    |
 
 ## 快速开始
@@ -208,9 +216,13 @@ chezmoi init --apply \
 
 ## 日常操作
 
-交互式 shell 会导出
-`JUSTFILE=${XDG_CONFIG_HOME:-$HOME/.config}/just/.justfile`（通常为
-`~/.config/just/.justfile`）。这个全局 justfile 包含：
+同一个 `Justfile.tmpl` 会渲染出两个 justfile：
+
+- `~/.config/just/.justfile` —— 全局文件。交互式 shell 导出
+  `JUSTFILE=${XDG_CONFIG_HOME:-$HOME/.config}/just/.justfile`，因此在任意目录
+  下 `just` 都使用它。
+- `~/Justfile` —— 同样的 recipe，**外加** `test`。但由于 `JUSTFILE` 已导出，
+  `just test` 并不会解析到它；请直接运行下面的测试命令。
 
 ```bash
 # Chezmoi
@@ -218,44 +230,49 @@ just apply
 just diff
 just update
 just re-add
+just edit <file>
 
 # Nix
 just up                 # 更新全部 flake inputs
 just upp nixpkgs        # 更新单个 input
-just gc
+just gc                 # 默认 7 天
 just verify
 just optimize
+just repl
+just repair <paths>
+just gcroot
 
 # 仅 macOS
 just darwin
+just darwin-debug
 just darwin-check
 just darwin-build
+just history
+just clean              # 默认 7 天
 ```
 
-全局 justfile **不包含**回归测试 recipe。实际测试请运行：
+回归测试与 lint 请直接运行：
 
 ```bash
 bash "$(chezmoi source-path)/tests/run.sh"
 pre-commit run --all-files
 ```
 
-其他生成的 recipe 还有 `edit`、`history`、`repl`、`clean`、`repair`、`gcroot`
-以及 Git 简写（`st`、`gd`、`gl`、`cm`、`push`、`pull`）；其中部分仅 macOS
-可用。`clean` 和 `gc` 默认保留 7 天，也可以传参覆盖。
+此外还有 Git 简写 recipe（`st`、`gd`、`gl`、`cm`、`push`、`pull`）。
 
 ## 包与工具管理
 
 包源是有意分层的，并不是所有清单都位于 `.chezmoidata/`。
 
-| 层               | 源文件                                                            | 管理内容                                                                                                                                                              |
-| ---------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Nix 用户 profile | `.chezmoidata/nix.yaml` + `nix-config/modules/profile.nix.tmpl`   | 通过 `flakey-profile` 管理 shared 包和 work 包；当前 `sysPkgs` 清单为空，macOS 系统设置/字体/服务仍由 `nix-darwin` 管理。                                             |
-| nix-darwin       | `nix-config/modules/*.tmpl`                                       | macOS defaults、字体、shell/PAM 设置、Nix index、Homebrew 集成和系统 launchd jobs。                                                                                   |
-| Homebrew         | `.chezmoidata/homebrew.yaml` + `nix-config/modules/apps.nix.tmpl` | taps、formulae、cask 和条件式 MAS 条目；不是锁定且可复现的 Nix 层。                                                                                                   |
-| aqua             | `private_dot_config/aquaproj-aqua/aqua.yaml` 与 `registry.yaml`   | 固定版本 CLI，包括 Claude/Codex、shell 工具、Kubernetes/security 工具、Kimi Code、Herdr、Slipway 和 qmk-hid-host。                                                    |
-| mise             | `private_dot_config/mise/config.toml.tmpl`                        | Node、Bun、Python、Go、Rust、Lua、Terraform、uv、pipx 工具、Pi、用量分析器、浏览器/媒体 CLI、`xurl` 和 `crosspost`。`npm:` 条目使用 Bun，但 Node 仍保留用于 runtime。 |
-| 直接 installer   | `.chezmoiscripts/00`、`09`、`15`、`16`                            | Determinate Nix、Paperlib、Cursor Agent 和 work-only Azure Functions Core Tools，版本/checksum 均来自仓库数据。                                                       |
-| Pi extensions    | `.chezmoidata/pi.yaml` + Pi settings                              | 五个外部 package 和二十个 `@signalridge` package；有意不 pin，由 Pi 每周的 `update --extensions` 刷新。                                                               |
+| 层               | 源文件                                                              | 管理内容                                                                                                                                                                                                               |
+| ---------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Nix 用户 profile | `.chezmoidata/nix.yaml` + `nix-config/modules/profile.nix.tmpl`     | 通过 `flakey-profile` 管理 shared 包和 work 包；当前 `sysPkgs` 清单为空，macOS 系统设置/字体/服务仍由 `nix-darwin` 管理。                                                                                              |
+| nix-darwin       | `nix-config/modules/*.tmpl`                                         | macOS defaults、字体、shell/PAM 设置、Nix index、Homebrew 集成和系统 launchd jobs。                                                                                                                                    |
+| Homebrew         | `.chezmoidata/homebrew.yaml` + `nix-config/modules/apps.nix.tmpl`   | taps、formulae、cask 和条件式 MAS 条目；不是锁定且可复现的 Nix 层。                                                                                                                                                    |
+| aqua             | `private_dot_config/aquaproj-aqua/{aqua,registry,aqua-policy}.yaml` | 固定版本 CLI：Claude Code、Codex、Antigravity CLI（`agy`）、shell/Kubernetes/security 工具，以及来自本地 `registry.yaml` 的 Kimi Code、Herdr、Slipway、qmk-hid-host 和 doggo。`aqua-policy.yaml` 授权该本地 registry。 |
+| mise             | `private_dot_config/mise/config.toml.tmpl`                          | Node、Bun、Python、Go、Rust、Lua、Terraform、uv、pipx 工具、Pi、用量分析器、浏览器/媒体 CLI、`xurl` 和 `crosspost`。`npm:` 条目使用 Bun，但 Node 仍保留用于 runtime。                                                  |
+| 直接 installer   | `.chezmoiscripts/00`、`09`、`15`、`16`                              | Determinate Nix、Paperlib、Cursor Agent 和 work-only Azure Functions Core Tools，版本/checksum 均来自仓库数据。                                                                                                        |
+| Pi extensions    | `.chezmoidata/pi.yaml` + Pi settings                                | 五个外部 package 和二十个 `@signalridge` package；有意不 pin，由 Pi 每周的 `update --extensions` 刷新。                                                                                                                |
 
 代表性工具包括 `eza`、`bat`、`fd`、`ripgrep`、`fzf`、`gh`、`ghq`、`just`、
 `lazygit`、`neovim`、`yazi`、`jj`、`xh`、`slumber`、`k9s`、`kubectl`、`helm`、
@@ -263,9 +280,30 @@ pre-commit run --all-files
 `aichat`、`agent-browser`、`hyperframes` 和 `impeccable`。完整清单以实际源文件
 为准。
 
+## 编辑器、终端与桌面
+
+`private_dot_config/` 承载的内容远多于上面的包管理表，它是工作站的其余部分：
+
+| 领域       | 托管的配置                                                                                                                                                                  |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 编辑器     | `nvim/` —— LazyVim，配套提交进仓库的 `lazy-lock.json`、`neoconf.json`，以及本地 `lua/config`、`lua/plugins` 覆盖（配色、AI、dotfiles）。                                    |
+| Shell 外观 | `sheldon/plugins.toml`（zsh 插件管理：ohmyzsh lib、`zsh-defer`、autosuggestions、syntax highlighting、`fzf-tab`、`enhancd`、`you-should-use`）、`starship.toml`、`atuin/`。 |
+| 终端       | `wezterm/wezterm.lua` 与随附的 `WezTerm.icns`；`terminal/Dracula.terminal` 供 Terminal.app 使用（由脚本 `21` 安装）。                                                       |
+| 多路复用   | `tmux/tmux.conf.tmpl`：TPM 加另外 17 个固定插件（tmux2k 状态栏含自定义 AI agent 段、sessionx、floax、extrakto、resurrect/continuum）；以及 Herdr 的 `herdr/config.toml`。   |
+| macOS 桌面 | `aerospace/`（平铺窗口管理）、`hammerspoon/`（输入法自动切换、麦克风/音量 watcher、Spoons）、`private_karabiner/`、`sofle/`（QMK/Vial 键盘布局）。                          |
+| Git 与评审 | `git/`、`jj/`、`delta/`、`lazygit/`、`git-cliff/`、`gh/`、`gh-dash/`。GitHub 走 HTTPS + `gh` credential helper，**刻意不使用** `insteadOf` 改写。                           |
+| 文件与观测 | `yazi/`、`bat/`、`bottom/`、`procs/`、`slumber/`、`watchexec/`、`tlrc/`、`lazydocker/`，以及 `stern/`、`grype/`、`syft/` 策略文件。                                         |
+| 服务与存储 | `systemd/user/`（Linux 上的 `mcp-reaper.service` 与 `.timer`）、`nix/nix.conf`、`gopass/config.tmpl`、`mise/`、`aquaproj-aqua/`、`just/`、`aichat/`、`letsencrypt/`。       |
+
+`tools/wezterm-icon/` 是脚本 `22` 调用的独立 Swift 工具，用于在 Homebrew 替换
+cask 之后重新应用 WezTerm 自定义图标。
+
 ## Shell Alias 与函数
 
-Shell 配置只在交互式 zsh 中加载。下列 alias 只有在目标命令存在时才会创建：
+Shell 文件位于 `dot_custom/`，应用到 `~/.custom/`（`exports.sh`、`alias.sh`、
+`functions.sh`、`utils.sh`、`eval.sh`、`fzf-tab.zsh`）；`~/.zshrc` 负责加载它们，
+并在非交互式 shell 中提前返回。未纳管的 `~/.custom/local.sh` 会最后加载，用于
+本机覆盖。下列 alias 只有在目标命令存在时才会创建：
 
 | Alias                                                 | 目标                                                                             |
 | ----------------------------------------------------- | -------------------------------------------------------------------------------- |
@@ -277,9 +315,15 @@ Shell 配置只在交互式 zsh 中加载。下列 alias 只有在目标命令�
 | `cxm`、`cxw`                                          | `codex-manage`、`codex-with`                                                     |
 | `k` / `kubectl`                                       | 安装了 `kubecolor` 时使用它；否则 `k` 指向 `kubectl`                             |
 
-`la`、`ll`、`lla`、`lt` 是 eza/listing helpers；`cp`、`mv`、`mkdir` 是带
-交互/安全选项的 alias（`-i`/`-v`，以及 `mkdir -p`）。`ripgrep`、`fd`、
-`zoxide` 会安装并集成，但 **`grep`、`find`、`cd` 并没有被 alias 替换**。
+`la` 和 `ll` 始终存在；`lla`、`lt` 仅在装有 eza 时才定义（使用 eza 的
+`--git`/`--tree`）。`cp`、`mv`、`mkdir` 是带交互/安全选项的 alias
+（`-i`/`-v`，以及 `mkdir -p`）。`ripgrep`、`fd`、`zoxide` 会安装并集成，但
+**`grep`、`find`、`cd` 并没有被 alias 替换**。
+
+zsh 下还有一组可在命令行任意位置展开的 global alias —— `L`（`| less`）、
+`G`（`| grep`）、`H`、`T`、`W`、`S`、`U`、`J`（`| jq`）、`CP`（`| pbcopy`）、
+`F`（`$(fzf)`），以及用于重定向的 `N`/`N1`/`N2`；另有 `galias` 列出它们、`yy`
+复制上一条命令到剪贴板。`take` 是 `mkcd` 的别名。
 
 常用函数：
 
@@ -305,15 +349,19 @@ worktree 和 branch switching。`AICOMMIT_PROVIDER` 可取 `claude`、`codex`、
 
 ### 托管的 harness
 
-| Harness          | 托管文件与行为                                                                                                                                                                       |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Claude Code      | `~/.claude/settings.json`、全局指令、hooks、statusline 和官方 integration plugins。                                                                                                  |
-| Codex CLI        | `~/.codex/config.toml`、project-document fallback 列表、lifecycle hooks、MCP 和 Slack plugin 配置。                                                                                  |
-| Pi               | `~/.pi/agent/settings.json`、`models.json`、`subagents.json`、workflow settings、themes、keybindings 和 MCP。Pi 使用原生 `/model`、`/login`；没有 Pi account wrapper 或 `pi-token`。 |
-| Cursor Agent CLI | 固定版本的 `agent`/`cursor-agent` binary，以及 `~/.cursor/cli-config.json`、`~/.cursor/mcp.json`。                                                                                   |
-| Kimi Code        | `~/.kimi-code/config.toml` safety defaults 和 `~/.kimi-code/mcp.json`；没有 account wrapper。                                                                                        |
-| Antigravity CLI  | 合并到 `~/.gemini/antigravity-cli/settings.json`；保留 runtime 管理的 model/trust 设置。                                                                                             |
-| aichat           | `~/.config/aichat/config.yaml`；当对应 `pi/...` gopass key 存在时写入 Kimi Moonshot 和 Doubao。                                                                                      |
+| Harness          | 托管文件与行为                                                                                                                                                                                                                                                                                                  |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code      | `~/.claude/settings.json`、`CLAUDE.md`、四个 `context/*.md`、`hooks/`、`statusline-command.sh`、`templates/*.yml`（CI 起步模板）和官方 integration plugins。                                                                                                                                                    |
+| Codex CLI        | `~/.codex/config.toml`、`AGENTS.md`、project-document fallback 列表、lifecycle hooks、MCP 和 Slack plugin 配置。                                                                                                                                                                                                |
+| Pi               | `~/.pi/agent/settings.json`、`models.json`、`subagents.json`、`workflows/settings.json`、`mcp.json`、`keybindings.json`、`APPEND_SYSTEM.md`、六个 `agents/*.md`、四套 theme、`pi-permission-system` 配置，以及 `~/.pi/web-search.json`。Pi 使用原生 `/model`、`/login`；没有 Pi account wrapper 或 `pi-token`。 |
+| Cursor Agent CLI | 固定版本的 `agent`/`cursor-agent` binary，以及 `~/.cursor/cli-config.json`、`~/.cursor/mcp.json`。                                                                                                                                                                                                              |
+| Kimi Code        | `~/.kimi-code/config.toml` safety defaults、`~/.kimi-code/mcp.json` 和 `~/.kimi-code/AGENTS.md`；没有 account wrapper。                                                                                                                                                                                         |
+| Antigravity CLI  | 合并到 `~/.gemini/antigravity-cli/settings.json`；保留 runtime 管理的 `model`、`permissions`、`trustedWorkspaces`。                                                                                                                                                                                             |
+| aichat           | `~/.config/aichat/config.yaml`；当对应 `pi/...` gopass key 存在时写入 Kimi Moonshot 和 Doubao。                                                                                                                                                                                                                 |
+
+`~/.claude/skills`、`~/.codex/skills`、`~/.pi/agent/skills`、`~/.cursor/skills`
+和 `~/.kimi-code/skills` 由 `dot_claude/run_after_ensure-skill-dirs.sh` 保证为
+真实目录；默认不在其中激活任何 skill。
 
 ### Claude 与 Codex accounts
 
@@ -383,6 +431,12 @@ phuryn/pm-skills、Reddit/daily.dev/X publishing skills、UI/UX/diagram skills�
 marketplace。全局 `ai-research-skills` CLI 由 mise 的 pipx/uvx backend 单独管理；
 不会安装 host skills 或 commands。
 
+有三个 skill 由本仓库自己编写（而非下载），并落在同一个库中：`dev/toolbelt`
+（全局 agent 指令引用的本地 CLI 清单）、`media/remotion`，以及 `social/oss-x-post`
+（内含带确认门的 `social-post` 与 `reddit-submit` 发布助手）。共享的 `/commit`
+command 位于 `~/.harnesses/commands/core/commit.md`，并被 symlink 到
+`~/.claude/commands/core` 和 `~/.codex/prompts/core-commit.md`。
+
 在项目目录运行 `skill-activate`，会将同一批选中的 skills 以 flat symlink 写入：
 
 ```text
@@ -412,6 +466,10 @@ marketplace。全局 `ai-research-skills` CLI 由 mise 的 pipx/uvx backend 单�
 | Codex          | Notion 加上上面的六个条目。                                                                                           |
 | Pi             | `context7`、`deepwiki`、`gitmcp` 是 lazy direct tools；`markitdown`、`arxiv` 是 lazy proxy tools。这里不声明 Tavily。 |
 | Cursor 与 Kimi | `context7`、`tavily`、`deepwiki`、`gitmcp`、`markitdown`、`arxiv`。                                                   |
+
+Pi 走的是另一条路径：托管的 `~/.pi/web-search.json` 为 `pi-web-access` 扩展配置
+Exa/Tavily 的路由组合，在调用时才从 gopass 读取 Tavily key，并禁用浏览器 cookie
+复用。
 
 `~/.local/bin/mcp-tavily` 运行时从 gopass 读取 `tavily/api_key`，再通过
 `bunx` 启动固定版本的 `tavily-mcp@0.2.16`。当对应的非 headless macOS 或


### PR DESCRIPTION
## Summary

Two related problems found while auditing the READMEs against the actual
configuration: the documentation had drifted, and the source tree had
accumulated files that `chezmoi apply` was copying into `$HOME`.

## Behaviour change (please read)

`.gitignore` keeps build artifacts out of git, but it does not stop chezmoi —
anything left in the source tree becomes a managed target. Three had
accumulated and were being applied:

| Entry | Applied as | What it was |
| --- | --- | --- |
| `result` | `~/result` | nix build symlink from an April `nix build` |
| `access.log` | `~/access.log` | 6.5 MB proxy connection log (domains + timestamps) |
| `" .chezmoiscripts"` | `~/ .chezmoiscripts` | empty dir, leading space in the name — a typo |

This PR mirrors the relevant `.gitignore` entries into `.chezmoiignore`
(`result`, `result-*`, `*.log`) so a `nix build` here, or a log dropped in
this directory, can no longer reach `$HOME`.

The stray entries and their already-applied copies were removed separately
(they were untracked/gitignored, so they produce no diff here). Ignoring a
path does not make chezmoi delete an existing target, so those needed
removing by hand.

Blast radius verified: managed targets drop from 3540 to 3538 — exactly
`result` and `access.log`, nothing else.

## Documentation fixes

Every factual claim in the three READMEs was checked against the source. Most
were already correct and were left alone. What did not match:

- Script `22` was listed as "macOS only"; `.chezmoiignore` also excludes it
  under `headless`, contradicting the profile table in the same document.
- The aqua row omitted `aqua-policy.yaml` (hashed by script `05`, authorizes
  the local registry), the Antigravity CLI, and `doggo`.
- Daily Operations claimed the justfile has no test recipe without explaining
  why `just test` fails. Both justfiles are now described, and the missing
  `darwin-debug`, `edit`, `repl`, `repair`, `gcroot`, `history` and `clean`
  recipes are listed.
- The repository map omitted `dot_custom/` — where every alias and function
  the README documents actually lives — plus `.chezmoi.toml.tmpl`,
  `.chezmoiignore`, `.chezmoitemplates/`, `init.sh`, `Justfile.tmpl` and
  `private_dot_ssh/`.
- `private_dot_config/` was summarised as "shell, tmux, tool, and service
  configuration" for 37 directories. The editor/terminal/desktop layer
  (LazyVim, WezTerm, AeroSpace, Hammerspoon, Karabiner/Sofle, yazi, atuin,
  starship, sheldon, jj/delta/lazygit/gh-dash) had no section at all; one was
  added.
- The shell section never named `dot_custom/` or `~/.custom/local.sh`, and
  omitted the zsh global aliases, `yy`, `galias` and `take`. The eza claim was
  also wrong: without eza, `lla` and `lt` are not defined at all.
- The harness table under-listed managed files: Claude's `context/*.md` and CI
  templates, Pi's six agent definitions, `APPEND_SYSTEM.md`, permission config
  and `web-search.json`, and the Kimi/Codex `AGENTS.md`.
- "Pi does not declare Tavily here" was literally true but misleading — Pi
  reaches Tavily and Exa through the managed `~/.pi/web-search.json`.
- The skills section covered only downloaded externals, never the three
  repository-authored skills (`dev/toolbelt`, `media/remotion`,
  `social/oss-x-post`) or the shared `/commit` command.

All three language versions were kept structurally identical (17 `##` sections
each).

Also corrects the gopass layout comment in `.chezmoidata/claude.yaml`, which
documented `claude/providers/{provider}/accounts/{base64url(account)}/api_key`
while the code uses `claude/<provider>/<account-label>/api_key`.

## Test plan

- [x] `bash tests/run.sh` — full suite OK (re-run after the `.chezmoiignore` change)
- [x] `pre-commit run --files ...` — all hooks pass on every changed file
- [x] `chezmoi managed` — 3540 → 3538, only the two intended targets dropped
- [x] `$HOME` verified clean of all three stray targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D55MBPR57MEVGZoZjMc3nV