### PR TITLE
chore(aqua): update pinned packages (2026-09-03)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -21,13 +21,13 @@ packages:
   # Moonshot's CDN (self-contained Node-SEA, no Node runtime). NOTE: the CDN's
   # `latest` can lag GitHub tags, so `aqua up` may propose a version not yet on the
   # CDN — keep this at a CDN-present version (binaries/<ver>/manifest.json resolves).
-  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.39.1
+  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.40.1
     registry: third-party
   # ----- standard registry -----
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.1.23
+  - name: google-antigravity/antigravity-cli@1.1.24
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.2
   - name: asciinema/asciinema@v3.2.1
@@ -40,14 +40,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.258
-  - name: openai/codex@rust-v0.152.1
+  - name: anthropics/claude-code@v2.1.259
+  - name: openai/codex@rust-v0.153.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.9.0
+  - name: jdx/mise@v2026.9.1
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -89,7 +89,7 @@ packages:
   - name: chmln/sd@v1.1.0
   - name: ducaale/xh@v0.26.2
   - name: watchexec/watchexec@v2.7.0
-  - name: joshmedeski/sesh@v2.28.0
+  - name: joshmedeski/sesh@v2.29.0
   - name: starship/starship@v1.26.0
   - name: JohnnyMorganz/StyLua@v2.5.2
   - name: Kampfkarren/selene@0.31.0
@@ -100,8 +100,8 @@ packages:
   - name: mvdan/sh@v3.14.0
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.16.5
-  - name: astral-sh/ty@0.0.77
-  - name: j178/prek@v0.5.1
+  - name: astral-sh/ty@0.0.78
+  - name: j178/prek@v0.5.2
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.13.2
   - name: goreleaser/goreleaser@v2.18.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.