### PR TITLE
chore(aqua): update pinned packages (2026-09-05)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -21,13 +21,13 @@ packages:
   # Moonshot's CDN (self-contained Node-SEA, no Node runtime). NOTE: the CDN's
   # `latest` can lag GitHub tags, so `aqua up` may propose a version not yet on the
   # CDN — keep this at a CDN-present version (binaries/<ver>/manifest.json resolves).
-  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.40.1
+  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.41.0
     registry: third-party
   # ----- standard registry -----
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.1.25
+  - name: google-antigravity/antigravity-cli@1.1.26
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.2
   - name: asciinema/asciinema@v3.2.1
@@ -40,8 +40,8 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.260
-  - name: openai/codex@rust-v0.153.2
+  - name: anthropics/claude-code@v2.1.261
+  - name: openai/codex@rust-v0.153.4
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
@@ -79,9 +79,9 @@ packages:
   - name: LuaLS/lua-language-server@3.19.1
   - name: tree-sitter/tree-sitter@v0.27.0
   - name: jj-vcs/jj@v0.45.1
-  - name: rclone/rclone@v1.75.0
+  - name: rclone/rclone@v1.75.1
   - name: o2sh/onefetch@2.28.1
-  - name: ip7z/7zip@26.02
+  - name: ip7z/7zip@26.03
   - name: ouch-org/ouch@0.8.2
   - name: Nukesor/pueue/pueue@v4.0.4
   - name: BurntSushi/ripgrep@15.2.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.