### PR TITLE
chore(aqua): update pinned packages (2026-09-06)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -27,7 +27,7 @@ packages:
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.1.26
+  - name: google-antigravity/antigravity-cli@1.1.27
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.2
   - name: asciinema/asciinema@v3.2.1
@@ -73,7 +73,7 @@ packages:
   - name: tldr-pages/tlrc@v1.13.1
   - name: ast-grep/ast-grep@0.45.3
   - name: casey/just@1.58.0
-  - name: jesseduffield/lazygit@v0.64.1
+  - name: jesseduffield/lazygit@v0.65.0
   - name: jesseduffield/lazydocker@v0.25.2
   - name: neovim/neovim@v0.12.5
   - name: LuaLS/lua-language-server@3.19.1
@@ -104,7 +104,7 @@ packages:
   - name: j178/prek@v0.5.2
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.13.2
-  - name: goreleaser/goreleaser@v2.18.0
+  - name: goreleaser/goreleaser@v2.18.1
   - name: orhun/git-cliff@v2.14.1
   - name: numtide/treefmt@v2.6.0
   - name: XAMPPRocky/tokei@14.0.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.