### PR TITLE
chore(aqua): update pinned packages (2026-09-08)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -14,7 +14,7 @@ packages:
     registry: third-party
   - name: signalridge/qmk-hid-host@v2026.06.14.1
     registry: third-party
-  - name: ogulcancelik/herdr@v0.8.2
+  - name: ogulcancelik/herdr@v0.9.0
     registry: third-party
   # Kimi Code CLI (K3). version_prefix in registry.yaml maps this semver onto the
   # `@moonshot-ai/kimi-code@<ver>` git tag; the binary itself is fetched from
@@ -47,7 +47,7 @@ packages:
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.9.1
+  - name: jdx/mise@v2026.9.2
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -100,7 +100,7 @@ packages:
   - name: mvdan/sh@v3.14.1
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.16.6
-  - name: astral-sh/ty@0.0.78
+  - name: astral-sh/ty@0.0.79
   - name: j178/prek@v0.5.2
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.13.2


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.