### PR TITLE
chore(aqua): update pinned packages (2026-09-10)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -21,17 +21,17 @@ packages:
   # Moonshot's CDN (self-contained Node-SEA, no Node runtime). NOTE: the CDN's
   # `latest` can lag GitHub tags, so `aqua up` may propose a version not yet on the
   # CDN — keep this at a CDN-present version (binaries/<ver>/manifest.json resolves).
-  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.41.0
+  - name: MoonshotAI/kimi-code@@moonshot-ai/kimi-code@0.42.0
     registry: third-party
   # ----- standard registry -----
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.1.27
+  - name: google-antigravity/antigravity-cli@1.2.0
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.2
   - name: asciinema/asciinema@v3.2.1
-  - name: atuinsh/atuin@v18.21.0
+  - name: atuinsh/atuin@v18.22.0
   - name: axodotdev/cargo-dist@v0.32.0 # `dist` — was a live-only cargo install
   - name: sigoden/aichat@v0.30.0
   - name: sharkdp/bat@v0.26.1
@@ -40,14 +40,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.263
-  - name: openai/codex@rust-v0.153.4
+  - name: anthropics/claude-code@v2.1.267
+  - name: openai/codex@rust-v0.154.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.9.2
+  - name: jdx/mise@v2026.9.4
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -60,7 +60,7 @@ packages:
   - name: fastfetch-cli/fastfetch@2.68.1
   - name: sharkdp/fd@v10.5.0
   - name: junegunn/fzf@v0.74.3
-  - name: gopasspw/gopass@v1.17.0
+  - name: gopasspw/gopass@v1.17.1
   - name: cli/cli@v2.100.0
   - name: dlvhdr/gh-dash@v4.25.2
   - name: x-motemen/ghq@v1.10.1
@@ -94,13 +94,13 @@ packages:
   - name: JohnnyMorganz/StyLua@v2.5.2
   - name: Kampfkarren/selene@0.31.0
   - name: crate-ci/typos@v1.50.1
-  - name: zizmorcore/zizmor@v1.30.0
+  - name: zizmorcore/zizmor@v1.30.1
   - name: gitleaks/gitleaks@v8.30.1
   - name: koalaman/shellcheck@v0.11.0
   - name: mvdan/sh@v3.14.1
   - name: rhysd/actionlint@v1.7.12
   - name: astral-sh/ruff@0.16.6
-  - name: astral-sh/ty@0.0.79
+  - name: astral-sh/ty@0.0.80
   - name: j178/prek@v0.5.2
   - name: golang.org/x/tools/gopls@v0.23.0
   - name: golangci/golangci-lint@v2.13.2
@@ -122,7 +122,7 @@ packages:
   - name: ajeetdsouza/zoxide@v0.10.0
   - name: derailed/k9s@v0.51.0
   - name: kubernetes/kubernetes/kubectl@v1.37.0
-  - name: helm/helm@v4.2.4
+  - name: helm/helm@v4.3.0
   - name: stern/stern@v1.34.0
   - name: kubecolor/kubecolor@v0.7.1
   - name: ahmetb/kubectx@v0.11.0
@@ -132,7 +132,7 @@ packages:
   - name: anchore/grype@v0.118.0
   - name: LucasPickering/slumber@v5.3.0
   - name: charmbracelet/gum@v2.0.0
-  - name: charmbracelet/vhs@v0.11.0
+  - name: charmbracelet/vhs@v0.12.0
   - name: terraform-linters/tflint@v0.64.0
   - name: quarto-dev/quarto-cli@v1.10.18
   - name: typst/typst@v0.15.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.