### PR TITLE
chore(aqua): update pinned packages (2026-09-11)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -40,14 +40,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.267
+  - name: anthropics/claude-code@v2.1.268
   - name: openai/codex@rust-v0.154.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.9.4
+  - name: jdx/mise@v2026.9.5
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1
@@ -60,7 +60,7 @@ packages:
   - name: fastfetch-cli/fastfetch@2.68.1
   - name: sharkdp/fd@v10.5.0
   - name: junegunn/fzf@v0.74.3
-  - name: gopasspw/gopass@v1.17.1
+  - name: gopasspw/gopass@v1.17.2
   - name: cli/cli@v2.100.0
   - name: dlvhdr/gh-dash@v4.25.2
   - name: x-motemen/ghq@v1.10.1
@@ -89,7 +89,7 @@ packages:
   - name: chmln/sd@v1.1.0
   - name: ducaale/xh@v0.26.2
   - name: watchexec/watchexec@v2.7.2
-  - name: joshmedeski/sesh@v2.29.0
+  - name: joshmedeski/sesh@v2.30.1
   - name: starship/starship@v1.26.0
   - name: JohnnyMorganz/StyLua@v2.5.2
   - name: Kampfkarren/selene@0.31.0
@@ -99,7 +99,7 @@ packages:
   - name: koalaman/shellcheck@v0.11.0
   - name: mvdan/sh@v3.14.1
   - name: rhysd/actionlint@v1.7.12
-  - name: astral-sh/ruff@0.16.6
+  - name: astral-sh/ruff@0.16.7
   - name: astral-sh/ty@0.0.80
   - name: j178/prek@v0.5.2
   - name: golang.org/x/tools/gopls@v0.23.0


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.