### PR TITLE
chore(aqua): update pinned packages (2026-09-12)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -27,12 +27,12 @@ packages:
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.2.0
+  - name: google-antigravity/antigravity-cli@1.2.1
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.2
   - name: asciinema/asciinema@v3.2.1
   - name: atuinsh/atuin@v18.22.0
-  - name: axodotdev/cargo-dist@v0.32.0 # `dist` — was a live-only cargo install
+  - name: axodotdev/cargo-dist@v0.33.0 # `dist` — was a live-only cargo install
   - name: sigoden/aichat@v0.30.0
   - name: sharkdp/bat@v0.26.1
   - name: eth-p/bat-extras@v2024.08.24
@@ -40,7 +40,7 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.268
+  - name: anthropics/claude-code@v2.1.269
   - name: openai/codex@rust-v0.154.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
@@ -59,7 +59,7 @@ packages:
   - name: crates.io/eza@0.23.5
   - name: fastfetch-cli/fastfetch@2.68.1
   - name: sharkdp/fd@v10.5.0
-  - name: junegunn/fzf@v0.74.3
+  - name: junegunn/fzf@v0.74.4
   - name: gopasspw/gopass@v1.17.2
   - name: cli/cli@v2.100.0
   - name: dlvhdr/gh-dash@v4.25.2
@@ -131,7 +131,7 @@ packages:
   - name: anchore/syft@v1.51.1
   - name: anchore/grype@v0.118.0
   - name: LucasPickering/slumber@v5.3.0
-  - name: charmbracelet/gum@v2.0.0
+  - name: charmbracelet/gum@v2.0.1
   - name: charmbracelet/vhs@v0.12.0
   - name: terraform-linters/tflint@v0.64.0
   - name: quarto-dev/quarto-cli@v1.10.18


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.