### PR TITLE
chore(aqua): update pinned packages (2026-09-13)

### DIFF
--- a/private_dot_config/aquaproj-aqua/aqua.yaml
+++ b/private_dot_config/aquaproj-aqua/aqua.yaml
@@ -27,7 +27,7 @@ packages:
   # Google Antigravity CLI (`agy`). Installed via aqua instead of the vendor's
   # `curl | bash` installer, which writes ~/.local/bin/agy and rewrites shell
   # profiles (PATH + alias purging) outside chezmoi's control.
-  - name: google-antigravity/antigravity-cli@1.2.1
+  - name: google-antigravity/antigravity-cli@1.2.2
   - name: nektos/act@v0.2.89
   - name: FiloSottile/age@v1.3.2
   - name: asciinema/asciinema@v3.2.1
@@ -40,14 +40,14 @@ packages:
     # keep a known-good release pinned.
     update:
       enabled: false
-  - name: anthropics/claude-code@v2.1.269
+  - name: anthropics/claude-code@v2.1.270
   - name: openai/codex@rust-v0.154.0
   - name: direnv/direnv@v2.37.1
   # Tagged 'bootstrap' so the aqua-install step (script 05) can install mise
   # first (`aqua i -t bootstrap`), then use it to put Go/Rust on PATH before
   # the full install — letting source-build backends (cargo/go_install, e.g.
   # eza/tokei/gopls) compile on a fresh machine.
-  - name: jdx/mise@v2026.9.5
+  - name: jdx/mise@v2026.9.6
     tags:
       - bootstrap
   - name: muesli/duf@v0.9.1


### PR DESCRIPTION
Automated `aqua update -p` for `private_dot_config/aquaproj-aqua/aqua.yaml`.